### PR TITLE
Implemented ToString() by delegating to Value.ToString()

### DIFF
--- a/ValueOf.Tests/ToString.cs
+++ b/ValueOf.Tests/ToString.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 
 namespace ValueOf.Tests
 {

--- a/ValueOf.Tests/ToString.cs
+++ b/ValueOf.Tests/ToString.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace ValueOf.Tests
+{
+    public class ToString
+    {
+        [Test]
+        public void ToStringReturnsValueToStringForSingleValuedObjects()
+        {
+            ClientRef clientRef1 = ClientRef.From("ASDF12345");
+            
+            Assert.AreEqual(clientRef1.Value, clientRef1.ToString());
+        }
+
+        [Test]
+        public void ToStringReturnsValueOfTupleForTupleValuedObjects()
+        {
+            Address address1 = Address.From(("16 Food Street", "London", Postcode.From("N1 1LT")));
+            
+            Assert.AreEqual(address1.Value.ToString(), address1.ToString());
+
+        }
+    }
+}

--- a/ValueOf/ValueOf.cs
+++ b/ValueOf/ValueOf.cs
@@ -56,5 +56,10 @@ namespace ValueOf
         {
             return EqualityComparer<TValue>.Default.GetHashCode(Value);
         }
+
+        public override string ToString()
+        {
+            return Value.ToString();
+        }
     }
 }


### PR DESCRIPTION
I have created bugs a couple of times this afternoon by supplying a ValueOf object to a method which expects a string, and the name of the type has been supplied rather than the string representation of the Value. E.g. given a class

```
namespace MyProgram {
    public class Password : ValueOf<string, Password> { }
}

```
when we call
```
System.Console.WriteLine(Password.From("Pa55w0rd"))

```
outputs  
```
MyProgram.Password
```

So this PR will make it output `Pa55w0rd` instead.