### PR TITLE
Factory for creating items and override for Equals method

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,21 @@ public class ValidatedClientRef : ValueOf<string, ValidatedClientRef>
 
 ```
 
+### Factory for creating your Types
+
+You can override the `protected TValue Create(TValue item) { } ` method, if you want to perform some logic when creating your types:
+
+```
+public class ProductId : ValueOf<string, ProductId>
+{
+    protected override string Create(string item)
+    {
+        return item?.ToLower();
+    }
+}
+
+```
+
 ## See Also
 
 If you liked this, you'll probably like another project of mine [OneOf](https://github.com/mcintyre321/OneOf) which provides Discriminated Unions for C#, allowing stronger compile time guarantees when writing branching logic.

--- a/ValueOf.Tests/Create.cs
+++ b/ValueOf.Tests/Create.cs
@@ -1,0 +1,21 @@
+﻿using NUnit.Framework;
+
+namespace ValueOf.Tests
+{
+    public class ProductId : ValueOf<string, ProductId>
+    {
+        protected override string Create(string item)
+        {
+            return item?.ToLower();
+        }
+    }
+
+    public class Create
+    {
+        [Test]
+        public void CreateFactory()
+        {
+            Assert.AreEqual("asdf12345", ProductId.From("ASDF12345").Value);
+        }
+    }
+}

--- a/ValueOf.Tests/Equals.cs
+++ b/ValueOf.Tests/Equals.cs
@@ -1,0 +1,38 @@
+﻿using NUnit.Framework;
+using System.Collections.Generic;
+
+namespace ValueOf.Tests
+{
+
+    public class CaseInsensitiveClientRef : ValueOf<string, CaseInsensitiveClientRef>
+    {
+        protected override bool Equals(ValueOf<string, CaseInsensitiveClientRef> other)
+        {
+            return EqualityComparer<string>.Default.Equals(Value.ToLower(), other.Value.ToLower());
+        }
+
+        public override int GetHashCode()
+        {
+            return EqualityComparer<string>.Default.GetHashCode(Value.ToLower());
+        }
+    }
+
+    public class Equals
+    {
+        [Test]
+        public void CaseInsensitiveEquals()
+        {
+            CaseInsensitiveClientRef clientRef1 = CaseInsensitiveClientRef.From("ASDF12345");
+            CaseInsensitiveClientRef clientRef2 = CaseInsensitiveClientRef.From("asdf12345");
+            Assert.AreEqual(clientRef1, clientRef2);
+            Assert.AreEqual(clientRef1.GetHashCode(), clientRef2.GetHashCode());
+            Assert.IsTrue(clientRef1 == clientRef2);
+
+            CaseInsensitiveClientRef clientRef3 = CaseInsensitiveClientRef.From("QWER98765");
+            Assert.AreNotEqual(clientRef1, clientRef3);
+            Assert.AreNotEqual(clientRef1.GetHashCode(), clientRef3.GetHashCode());
+            Assert.IsFalse(clientRef1 == clientRef3);
+        }
+
+    }
+}

--- a/ValueOf/ValueOf.cs
+++ b/ValueOf/ValueOf.cs
@@ -20,6 +20,11 @@ namespace ValueOf
         {
         }
 
+        protected virtual TValue Create(TValue item)
+        {
+            return item;
+        }
+
         static ValueOf()
         {
             var ctor = typeof(TThis).GetTypeInfo().DeclaredConstructors.First();
@@ -34,7 +39,7 @@ namespace ValueOf
         public static TThis From(TValue item)
         {
             var x = Factory();
-            x.Value = item;
+            x.Value = x.Create(item);
             x.Validate();
             return x;
         }

--- a/ValueOf/ValueOf.cs
+++ b/ValueOf/ValueOf.cs
@@ -45,7 +45,7 @@ namespace ValueOf
         }
 
 
-        protected bool Equals(ValueOf<TValue, TThis> other)
+        protected virtual bool Equals(ValueOf<TValue, TThis> other)
         {
             return EqualityComparer<TValue>.Default.Equals(Value, other.Value);
         }


### PR DESCRIPTION
Hi!

First of all: Thanks for this great package!

I do have two feature suggestions:
1. I had the use case where I wanted to execute some logic for the given value which is passed to the `.From` method when creating `ValueOf` items. This is useful for example for doing some sanitation logic, e.g. trimming whitespace, transforming the given value to lower case, etc. So I created a `Create` method which can be overridden in derived types. The default implementation just passes the given value from the `.From` method. (See the test cases for an example.)
2. I added the possibility to override the `ValueOf.Equals` method. This is useful for example if you want to implement an case-insensitive comparision of two types but you don't want to transform the given values to lowercase beforehand.

Please let me know what you think.

Cheers!