### PR TITLE
TypeConverter for serializing and deserializing ValueOf types

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,29 +10,27 @@
 
 ValueOf lets you define ValueObject Types in a single line of code. Use them everywhere to strengthen your codebase.
 
-```
+```csharp
 public class EmailAddress : ValueOf<string, EmailAddress> { }
 
 ...
 
 EmailAddress emailAddress = EmailAddress.From("foo@bar.com");
-
 ```
 
 The ValueOf class implements `.Equals` and `.GetHashCode()` for you.
 
 You can use C# 7 Tuples for more complex Types with multiple values:
 
-```
-    public class Address : ValueOf<(string firstLine, string secondLine, Postcode postcode), Address> { }
-
+```csharp
+public class Address : ValueOf<(string firstLine, string secondLine, Postcode postcode), Address> { }
 ```
 
 ### Validation
 
 You can add validation to your Types by overriding the `protected void Validate() { } ` method:
 
-```
+```csharp
 public class ValidatedClientRef : ValueOf<string, ValidatedClientRef>
 {
     protected override void Validate()
@@ -41,8 +39,19 @@ public class ValidatedClientRef : ValueOf<string, ValidatedClientRef>
             throw new ArgumentException("Value cannot be null or empty");
     }
 }	
-
 ```
+
+### Serialization and Deserialization
+
+When serializing and deserilizing your types, e.g. with `Newtonsoft.Json` you need to give the serializer a hint that he knows how to correctly serialize and deserialize the types.
+`ValueOfTpeConverter` does that for you in a generic way by simply adding an attribute to your type:
+
+```csharp
+[TypeConverter(typeof(ValueOfTypeConverter<string, ClientId>))]
+public class ClientId : ValueOf<string, ClientId> { }
+```
+
+With this `TypeConverter` attribute in place, the `ClientId` gets serialized to a `string` and a `string` gets deserialized into a `ClientId` type.
 
 ## See Also
 

--- a/ValueOf.Tests/TypeConverter.cs
+++ b/ValueOf.Tests/TypeConverter.cs
@@ -1,0 +1,78 @@
+﻿using Newtonsoft.Json;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ValueOf.Tests
+{
+    [TypeConverter(typeof(ValueOfTypeConverter<string, ClientId>))]
+    public class ClientId : ValueOf<string, ClientId> { }
+
+    public class ClientIdWithoutTypeConverter : ValueOf<string, ClientIdWithoutTypeConverter> { }
+
+
+    public class ClientIdModel
+    {
+        public ClientId ClientId { get; set; }
+    }
+
+    public class ClientIdWithoutTypeConverterModel
+    {
+        public ClientIdWithoutTypeConverter ClientId { get; set; }
+    }
+
+
+    public class TypeConverter
+    {
+        [Test]
+        public void ConvertToJsonWithoutTypeConverter()
+        {
+            var model = new ClientIdWithoutTypeConverterModel
+            {
+                ClientId = ClientIdWithoutTypeConverter.From("asdf12345")
+            };
+
+            var json = JsonConvert.SerializeObject(model);
+
+            // This is usually not what we want when serializing ValueOf types.
+            // We don't want the value to get wrapped inside the "Value" property when serilzing.
+            // With the TypeConverter, this can be avoided.
+            Assert.AreEqual("{\"ClientId\":{\"Value\":\"asdf12345\"}}", json);
+        }
+
+        [Test]
+        public void ConvertToJsonWithTypeConverter()
+        {
+            var model = new ClientIdModel
+            {
+                ClientId = ClientId.From("asdf12345")
+            };
+
+            var json = JsonConvert.SerializeObject(model);
+            Assert.AreEqual("{\"ClientId\":\"asdf12345\"}", json);
+        }
+
+        [Test]
+        public void ConvertFromJsonWithoutTypeConverter()
+        {
+            var json = "{\"ClientId\":\"asdf12345\"}";
+
+            // Without using a TypeConverter, the JSON serializer does not know, how to create the ValueOf type and throws an exception.
+            var exception = Assert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject<ClientIdWithoutTypeConverterModel>(json));
+            Assert.AreEqual("Error converting value \"asdf12345\" to type 'ValueOf.Tests.ClientIdWithoutTypeConverter'. Path 'ClientId', line 1, position 23.", exception.Message);
+        }
+
+        [Test]
+        public void ConvertFromJsonWithTypeConverter()
+        {
+            var json = "{\"ClientId\":\"asdf12345\"}";
+            var model = JsonConvert.DeserializeObject<ClientIdModel>(json);
+
+            Assert.AreEqual(ClientId.From("asdf12345"), model.ClientId);
+        }
+    }
+}

--- a/ValueOf.Tests/ValueOf.Tests.csproj
+++ b/ValueOf.Tests/ValueOf.Tests.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="nunit" Version="3.6.1" />
     <PackageReference Include="System.ValueTuple" Version="4.3.1" />
   </ItemGroup>

--- a/ValueOf/ValueOf.csproj
+++ b/ValueOf/ValueOf.csproj
@@ -20,6 +20,7 @@ Use ValueTuples for multi property values e.g `class Address : ValueOf&lt;(strin
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
   </ItemGroup>
 
 </Project>

--- a/ValueOf/ValueOfTypeConverter.cs
+++ b/ValueOf/ValueOfTypeConverter.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.ComponentModel;
+using System.Globalization;
+
+namespace ValueOf
+{
+    /// <summary>
+    /// Type converter for <see cref="ValueOf{TValue, TThis}"/> types to allow seamingless serialization and deserialization.
+    /// Use this type as parameter for the <see cref="TypeConverterAttribute"/>.
+    /// </summary>
+    public class ValueOfTypeConverter<TValue, TThis> : TypeConverter
+        where TThis : ValueOf<TValue, TThis>, new()
+    {
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            if (sourceType == typeof(TValue))
+            {
+                return true;
+            }
+
+            return base.CanConvertFrom(context, sourceType);
+        }
+
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            if (value is TValue tValue)
+            {
+                return ValueOf<TValue, TThis>.From(tValue);
+            }
+
+            return base.ConvertFrom(context, culture, value);
+        }
+
+        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        {
+            if (destinationType == typeof(TValue))
+            {
+                return ((TThis)value).Value;
+            }
+
+            return base.ConvertTo(context, culture, value, destinationType);
+        }
+    }
+}


### PR DESCRIPTION
Hi!

This is my second PR here in this repository.

I added a [`TypeConverter`](https://docs.microsoft.com/en-us/dotnet/api/system.componentmodel.typeconverter?view=netframework-4.8) for `ValueOf` types. This is needed, if you want to serialize and deserialize types, e.g. with `Newtonsoft.Json`. The serializer needs a hint how to serialize and deserialize `ValueOf` types correctly. (e.g. a `string` is correctly deserialized to a `ClientId`).

The generic `ValueOfTypeConverter` can simply be used as the following. (See the test cases for details):
```csharp
[TypeConverter(typeof(ValueOfTypeConverter<string, ClientId>))]
public class ClientId : ValueOf<string, ClientId> { }
```

Note that this feature adds a dependency to `System.ComponentModel.TypeConverter`.

Please let me know what you think.

Cheers!