### PR TITLE
Implicitly convert to TValue

### DIFF
--- a/ValueOf.Tests/Equals.cs
+++ b/ValueOf.Tests/Equals.cs
@@ -27,12 +27,12 @@ namespace ValueOf.Tests
             Assert.AreEqual(clientRef1, clientRef2);
             Assert.AreEqual(clientRef1.GetHashCode(), clientRef2.GetHashCode());
             Assert.IsTrue(clientRef1 == clientRef2);
+            Assert.IsTrue(clientRef1 == "ASDF12345");
 
             CaseInsensitiveClientRef clientRef3 = CaseInsensitiveClientRef.From("QWER98765");
             Assert.AreNotEqual(clientRef1, clientRef3);
             Assert.AreNotEqual(clientRef1.GetHashCode(), clientRef3.GetHashCode());
             Assert.IsFalse(clientRef1 == clientRef3);
         }
-
     }
 }

--- a/ValueOf/ValueOf.cs
+++ b/ValueOf/ValueOf.cs
@@ -82,6 +82,11 @@ namespace ValueOf
             return !(a == b);
         }
 
+        public static implicit operator TValue(ValueOf<TValue, TThis> a)
+        {
+            return a.Value;
+        }
+
         public override string ToString()
         {
             return Value.ToString();


### PR DESCRIPTION
Allows you to skip writing `.Value` everywhere.
e.g. `clientRef1 == "ASDF12345"` instead of 
`clientRef1.Value == "ASDF12345"`