### PR TITLE
Add TypeConverter support for generic bindings

### DIFF
--- a/ValueOf.Tests/Example.cs
+++ b/ValueOf.Tests/Example.cs
@@ -1,4 +1,6 @@
-﻿using NUnit.Framework;
+﻿using System.ComponentModel;
+using System.Globalization;
+using NUnit.Framework;
 
 namespace ValueOf.Tests
 {
@@ -32,6 +34,16 @@ namespace ValueOf.Tests
             Address address3 = Address.From(("17 Food Street", "London", Postcode.From("N1 1LT")));
             Assert.AreNotEqual(address1, address3);
             Assert.AreNotEqual(address1.GetHashCode(), address3.GetHashCode());
+        }
+    
+        [Test]
+        public void TypeConverterExample()
+        {
+            var converter = TypeDescriptor.GetConverter(typeof(ClientRef));
+            Assert.IsTrue(converter.CanConvertFrom(null, typeof(string)));
+            var converted = converter.ConvertFrom(null, CultureInfo.CurrentCulture, "me");
+            Assert.IsInstanceOf<ClientRef>(converted);
+            Assert.AreEqual((converted as ClientRef).Value, "me");
         }
     }
 }

--- a/ValueOf/ValueOf.csproj
+++ b/ValueOf/ValueOf.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net451;netcoreapp1.1;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net451;netstandard2.0</TargetFrameworks>
     <Authors>Harry McIntyre</Authors>
     <Title>ValueOf - Easy 'One-Liner' Value Objects for c#. Get over your Primitive Obsession!</Title>
     <Company>Harry McIntyre</Company>


### PR DESCRIPTION
Implements a generic `TypeConverter`. This helps in situations when binding using generic types (e.g. ASP.NET).

Example (using Carter)

Before:
`StudyId.From(var studyId = ctx.Request.RouteValues.As<string>("studyid"));`

After:
`var studyId = ctx.Request.RouteValues.As<StudyId>("studyid");`

Unfortuantely, TypeDescriptions and TypeDescriptionProviders are not supported in .net_standard 1.3. Had to promote to .net_standard 2.0.