### PR TITLE
skip static constructors when creating object factory

### DIFF
--- a/ValueOf.Tests/StaticConstructor.cs
+++ b/ValueOf.Tests/StaticConstructor.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Diagnostics;
+
+using NUnit.Framework;
+
+namespace ValueOf.Tests
+{
+    class StaticConstructor
+    {
+        [Test]
+        public void ClassesDerivedFromValueOfCanHaveStaticConstructor()
+        {
+            Assert.DoesNotThrow(() => ValueWithStaticConstructor.From(42));
+        }
+    }
+
+    public class ValueWithStaticConstructor : ValueOf<int, ValueWithStaticConstructor>
+    {
+        static ValueWithStaticConstructor()
+        {
+            Debug.WriteLine("pretending this needs to be here");
+        }
+    }
+}

--- a/ValueOf/ValueOf.cs
+++ b/ValueOf/ValueOf.cs
@@ -25,7 +25,7 @@ namespace ValueOf
             ConstructorInfo ctor = typeof(TThis)
                 .GetTypeInfo()
                 .DeclaredConstructors
-                .First();
+                .First(ctr => !ctr.IsStatic);
 
             var argsExp = new Expression[0];
             NewExpression newExp = Expression.New(ctor, argsExp);


### PR DESCRIPTION
Currently, classes derived from ValueOf<,> cannot have just static constructors, but also need to declare instance constructor and place it above the static one, otherwise Factory creation will fail